### PR TITLE
feat: add class playerInteractEvent

### DIFF
--- a/Bedwars/src/at/fabiadam/listener/playerInteractEvent.java
+++ b/Bedwars/src/at/fabiadam/listener/playerInteractEvent.java
@@ -1,0 +1,17 @@
+package at.fabiadam.listener;
+
+
+import org.bukkit.Bukkit;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerInteractEvent;
+
+public class playerInteractEvent implements Listener {
+
+    @EventHandler
+    public void onPlayerInteract (PlayerInteractEvent event){
+        if(event.getPlayer().getWorld().getName().equals("world_bedwars_l")){
+            event.setCancelled(true);
+        }
+    }
+}


### PR DESCRIPTION
- add player is not allowed to break blocks in world "world_bedwars_l"