### PR TITLE
fix: only survival players must die falling down

### DIFF
--- a/Bedwars/src/at/fabiadam/listener/playerMoveEvent.java
+++ b/Bedwars/src/at/fabiadam/listener/playerMoveEvent.java
@@ -3,6 +3,7 @@ package at.fabiadam.listener;
 import at.fabiadam.main.MainBedwars;
 import at.fabiadam.objects.Team;
 import at.fabiadam.util.BedwarsUtil;
+import org.bukkit.GameMode;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerMoveEvent;
@@ -21,6 +22,7 @@ public class playerMoveEvent implements Listener {
     public void onPlayerMove(PlayerMoveEvent event) {
         if(event.getPlayer().getWorld().getName().equals("world_bedwars")) {
             if(event.getPlayer().getLocation().getY() <= 0) {
+                if(event.getPlayer().getGameMode() != GameMode.SURVIVAL) return;
                 this.plugin = MainBedwars.getPlugin();
                 this.util = plugin.getUtil();
                 event.getPlayer().setHealth(0);


### PR DESCRIPTION
- before this, you also died when falling below y=0 in creative mode